### PR TITLE
feat: add branded key to CommonKeyValueDao

### DIFF
--- a/src/kv/commonKeyValueDao.ts
+++ b/src/kv/commonKeyValueDao.ts
@@ -53,7 +53,7 @@ export type CommonKeyValueDaoSaveOptions = CommonKeyValueDBSaveBatchOptions
 // todo: logging
 // todo: readonly
 
-export class CommonKeyValueDao<T> {
+export class CommonKeyValueDao<T, Key extends string = string> {
   constructor(cfg: CommonKeyValueDaoCfg<T>) {
     this.cfg = {
       hooks: {},
@@ -89,19 +89,19 @@ export class CommonKeyValueDao<T> {
     } as T
   }
 
-  async getById(id?: string): Promise<T | null> {
+  async getById(id?: Key): Promise<T | null> {
     if (!id) return null
     const [r] = await this.getByIds([id])
     return r?.[1] || null
   }
 
-  async getByIdAsBuffer(id?: string): Promise<Buffer | null> {
+  async getByIdAsBuffer(id?: Key): Promise<Buffer | null> {
     if (!id) return null
     const [r] = await this.cfg.db.getByIds(this.cfg.table, [id])
     return r?.[1] || null
   }
 
-  async requireById(id: string): Promise<T> {
+  async requireById(id: Key): Promise<T> {
     const [r] = await this.getByIds([id])
 
     if (!r) {
@@ -115,7 +115,7 @@ export class CommonKeyValueDao<T> {
     return r[1]
   }
 
-  async requireByIdAsBuffer(id: string): Promise<Buffer> {
+  async requireByIdAsBuffer(id: Key): Promise<Buffer> {
     const [r] = await this.cfg.db.getByIds(this.cfg.table, [id])
 
     if (!r) {
@@ -129,7 +129,7 @@ export class CommonKeyValueDao<T> {
     return r[1]
   }
 
-  async getByIdOrEmpty(id: string, part: Partial<T> = {}): Promise<T> {
+  async getByIdOrEmpty(id: Key, part: Partial<T> = {}): Promise<T> {
     const [r] = await this.getByIds([id])
     if (r) return r[1]
 
@@ -139,7 +139,7 @@ export class CommonKeyValueDao<T> {
     } as T
   }
 
-  async patch(id: string, patch: Partial<T>, opt?: CommonKeyValueDaoSaveOptions): Promise<T> {
+  async patch(id: Key, patch: Partial<T>, opt?: CommonKeyValueDaoSaveOptions): Promise<T> {
     const v: T = {
       ...(await this.getByIdOrEmpty(id)),
       ...patch,
@@ -150,7 +150,7 @@ export class CommonKeyValueDao<T> {
     return v
   }
 
-  async getByIds(ids: string[]): Promise<KeyValueTuple<string, T>[]> {
+  async getByIds(ids: Key[]): Promise<KeyValueTuple<string, T>[]> {
     const entries = await this.cfg.db.getByIds(this.cfg.table, ids)
     if (!this.cfg.hooks.mapBufferToValue) return entries as any
 
@@ -160,20 +160,20 @@ export class CommonKeyValueDao<T> {
     ])
   }
 
-  async getByIdsAsBuffer(ids: string[]): Promise<KeyValueTuple<string, Buffer>[]> {
-    return await this.cfg.db.getByIds(this.cfg.table, ids)
+  async getByIdsAsBuffer(ids: Key[]): Promise<KeyValueTuple<Key, Buffer>[]> {
+    return (await this.cfg.db.getByIds(this.cfg.table, ids)) as KeyValueTuple<Key, Buffer>[]
   }
 
-  async save(id: string, value: T, opt?: CommonKeyValueDaoSaveOptions): Promise<void> {
+  async save(id: Key, value: T, opt?: CommonKeyValueDaoSaveOptions): Promise<void> {
     await this.saveBatch([[id, value]], opt)
   }
 
-  async saveAsBuffer(id: string, value: Buffer, opt?: CommonKeyValueDaoSaveOptions): Promise<void> {
+  async saveAsBuffer(id: Key, value: Buffer, opt?: CommonKeyValueDaoSaveOptions): Promise<void> {
     await this.cfg.db.saveBatch(this.cfg.table, [[id, value]], opt)
   }
 
   async saveBatch(
-    entries: KeyValueTuple<string, T>[],
+    entries: KeyValueTuple<Key, T>[],
     opt?: CommonKeyValueDaoSaveOptions,
   ): Promise<void> {
     const { mapValueToBuffer } = this.cfg.hooks
@@ -195,11 +195,11 @@ export class CommonKeyValueDao<T> {
     await this.cfg.db.saveBatch(this.cfg.table, entries, opt)
   }
 
-  async deleteByIds(ids: string[]): Promise<void> {
+  async deleteByIds(ids: Key[]): Promise<void> {
     await this.cfg.db.deleteByIds(this.cfg.table, ids)
   }
 
-  async deleteById(id: string): Promise<void> {
+  async deleteById(id: Key): Promise<void> {
     await this.cfg.db.deleteByIds(this.cfg.table, [id])
   }
 
@@ -259,7 +259,7 @@ export class CommonKeyValueDao<T> {
    *
    * Returns the new value of the field.
    */
-  async increment(id: string, by = 1): Promise<number> {
+  async increment(id: Key, by = 1): Promise<number> {
     return await this.cfg.db.increment(this.cfg.table, id, by)
   }
 }


### PR DESCRIPTION
🎺🎺🎺  Proposal! 🎺🎺🎺

In this PR, I propose to add the option to specify the type of `Key` for `CommonKeyValueDao`.

### Why?

This would allow us to easily introduce type safety in dependent projects.
Similar to how we can do the same by specifying the `id` field in Models used with CommonDao.
E.g:

<img width="916" alt="Screenshot 2024-10-09 at 16 27 06" src="https://github.com/user-attachments/assets/616b576e-f9cd-4f6c-9693-555b08b7ad48">

### Yes, but why?

As in the example above, the ID is not a simple string but a string built from non-unique parts.
In CommonDao world, we provide the `naturalId()` helper for that, but the users don't really need to know about it, as the underlying hooks take care of it.
If we provide a `naturalId()` function in CKVDao, noone would actually realize that it needs to be used, unless... you guess it... we nudge them with a branded type.

(It does not seem feasible to implement the same hook-mechanism in CKVDao, because we save primitives not object which could supply the data for natural id calculation - as opposed to CDao.)

### Why not put it in CommonKeyValueDB too?

The purpose of this change is to provide type safety for/against the users of CKVDao.
Most developers do not interact directly with the CKVDb.
Adding this generic type there is a possibility but not a necessity.

(Also interesting to note that the value type (`T`) is not passed on to the DB level either, because the underlying `Buffer` makes it ignorant/impervious to what value type the Dao level specifies.)

---

I don't feel strongly about this. If you don't immediately love it, we can drop it.