### PR TITLE
refactor: rethink CommonKeyValueDB

### DIFF
--- a/src/adapter/inmemory/inMemoryKeyValueDB.test.ts
+++ b/src/adapter/inmemory/inMemoryKeyValueDB.test.ts
@@ -1,12 +1,7 @@
-import { CommonKeyValueDao } from '../../kv/commonKeyValueDao'
-import { runCommonKeyValueDaoTest, runCommonKeyValueDBTest, TEST_TABLE } from '../../testing'
+import { runCommonKeyValueDaoTest, runCommonKeyValueDBTest } from '../../testing'
 import { InMemoryKeyValueDB } from './inMemoryKeyValueDB'
 
 const db = new InMemoryKeyValueDB()
-const dao = new CommonKeyValueDao<Buffer>({
-  db,
-  table: TEST_TABLE,
-})
 
 describe('runCommonKeyValueDBTest', () => runCommonKeyValueDBTest(db))
-describe('runCommonKeyValueDaoTest', () => runCommonKeyValueDaoTest(dao))
+describe('runCommonKeyValueDaoTest', () => runCommonKeyValueDaoTest(db))

--- a/src/kv/commonKeyValueDB.ts
+++ b/src/kv/commonKeyValueDB.ts
@@ -1,4 +1,4 @@
-import { StringMap, UnixTimestampNumber } from '@naturalcycles/js-lib'
+import { Integer, KeyValueTuple, UnixTimestampNumber } from '@naturalcycles/js-lib'
 import { ReadableTyped } from '@naturalcycles/nodejs-lib'
 import { CommonDBCreateOptions } from '../db.model'
 
@@ -29,48 +29,41 @@ export interface CommonKeyValueDB {
    *
    * Currently it is NOT required to maintain the same order as input `ids`.
    */
-  getByIds: (table: string, ids: string[]) => Promise<KeyValueDBTuple[]>
+  getByIds: <V>(table: string, ids: string[]) => Promise<KeyValueTuple<string, V>[]>
 
   deleteByIds: (table: string, ids: string[]) => Promise<void>
 
-  saveBatch: (
+  saveBatch: <V>(
     table: string,
-    entries: KeyValueDBTuple[],
+    entries: KeyValueTuple<string, V>[],
     opt?: CommonKeyValueDBSaveBatchOptions,
   ) => Promise<void>
 
   streamIds: (table: string, limit?: number) => ReadableTyped<string>
-  streamValues: (table: string, limit?: number) => ReadableTyped<Buffer>
-  streamEntries: (table: string, limit?: number) => ReadableTyped<KeyValueDBTuple>
+  streamValues: <V>(table: string, limit?: number) => ReadableTyped<V>
+  streamEntries: <V>(table: string, limit?: number) => ReadableTyped<KeyValueTuple<string, V>>
 
   count: (table: string) => Promise<number>
 
   /**
-   * Increments the value of a key in a table by a given amount.
-   * Default increment is 1 when `by` is not provided.
-   *
-   * Returns the new value.
-   *
-   * @experimental
-   */
-  increment: (table: string, id: string, by?: number) => Promise<number>
-
-  /**
    * Perform a batch of Increment operations.
-   * Given incrementMap, increment each key of it by the given amount (value of the map).
+   * Given entries array, increment each key of it (1st index of the tuple) by the given amount (2nd index of the tuple).
    *
    * Example:
-   * { key1: 2, key2: 3 }
+   * [
+   *   ['key1', 2],
+   *   ['key2', 3],
+   * ]
    * would increment `key1` by 2, and `key2` by 3.
    *
-   * Returns the incrementMap with the same keys and updated values.
+   * Returns the entries array with tuples of the same structure, with updated numbers.
    *
    * @experimental
    */
-  incrementBatch: (table: string, incrementMap: StringMap<number>) => Promise<StringMap<number>>
+  incrementBatch: (table: string, entries: IncrementTuple[]) => Promise<IncrementTuple[]>
 }
 
-export type KeyValueDBTuple = [key: string, value: Buffer]
+export type IncrementTuple = [key: string, value: Integer]
 
 export interface CommonKeyValueDBSaveBatchOptions {
   /**

--- a/src/kv/commonKeyValueDaoMemoCache.ts
+++ b/src/kv/commonKeyValueDaoMemoCache.ts
@@ -2,7 +2,7 @@ import { AsyncMemoCache, localTime, MISS, NumberOfSeconds } from '@naturalcycles
 import { CommonKeyValueDao } from './commonKeyValueDao'
 
 export interface CommonKeyValueDaoMemoCacheCfg<VALUE> {
-  dao: CommonKeyValueDao<VALUE>
+  dao: CommonKeyValueDao<string, VALUE>
 
   /**
    * If set, every `set()` will set `expireAt` (TTL) option.
@@ -18,7 +18,7 @@ export interface CommonKeyValueDaoMemoCacheCfg<VALUE> {
  * Also, does not support .clear(), as it's more dangerous than useful to actually
  * clear the whole table/cache.
  */
-export class CommonKeyValueDaoMemoCache<VALUE = any> implements AsyncMemoCache<string, VALUE> {
+export class CommonKeyValueDaoMemoCache<VALUE> implements AsyncMemoCache<string, VALUE> {
   constructor(private cfg: CommonKeyValueDaoMemoCacheCfg<VALUE>) {}
 
   async get(k: string): Promise<VALUE | typeof MISS> {


### PR DESCRIPTION
Why?

`increment` use case brought the need to support not only `Buffer` as the Value of KeyValueDao, but also a `number`.

We escalated this case into a statement that it should support `any` data type, including number, Buffer, string, object, anything. Same as CommonDB. In the future we may be more specific in the support manifest of what data types are supported.

CommonKeyValueDB now uses `V` generic in its methods to indicate the expected Value type. It is **type-only** change, as it doesn't do any data transformation.

CommonKeyValueDao, in turn, **supports** transformation (if cfg.transformer is provided), but by default also not transforming any data and just passes it into/over from DB.

`squash-on-green`