### PR TITLE
fix: fix KeyValueDaoTest

### DIFF
--- a/src/testing/keyValueDaoTest.ts
+++ b/src/testing/keyValueDaoTest.ts
@@ -5,7 +5,10 @@ import { createTestItemsBM, TEST_TABLE, TestItemBM } from './test.model'
 
 const testItems = createTestItemsBM(4)
 const testIds = testItems.map(e => e.id)
-const testEntries: KeyValueTuple<string, TestItemBM>[] = testItems.map(e => [e.id, e])
+const testEntries: KeyValueTuple<string, any>[] = testItems.map(e => [
+  e.id,
+  Buffer.from(`${e.id}value`),
+])
 
 export function runCommonKeyValueDaoTest(db: CommonKeyValueDB): void {
   const dao = new CommonKeyValueDao<string, TestItemBM>({


### PR DESCRIPTION
Not to be merged (probably)

### Problem statement

this was the original shape of the `testEntries`
<img width="740" alt="Screenshot 2024-10-17 at 17 24 49" src="https://github.com/user-attachments/assets/41b3f0d9-a0b5-45ac-a4ea-4c27386d35dd">

this is the current:
<img width="674" alt="Screenshot 2024-10-17 at 17 25 14" src="https://github.com/user-attachments/assets/03f9653f-b936-41a3-bfef-56c92b7f5364">

with this change the redis-lib manual tests (running this `keyValueDaoTest()`) fail:

<img width="499" alt="Screenshot 2024-10-17 at 17 22 52" src="https://github.com/user-attachments/assets/8c3cb6a7-a505-4ea8-b9aa-626190783704">
<img width="410" alt="Screenshot 2024-10-17 at 17 23 12" src="https://github.com/user-attachments/assets/eaf1550f-dc72-434d-87de-b70ae86e9cea">

With the reversion shown in this PR, every test passes.

Since the Dao is defined in this lib and not in `redis-lib`, I don't think the issue should be fixed in `redis-lib`.

The `any` type is a smell, as it should be `Buffer` - but then it raises other type errors.