### PR TITLE
feat: add `requireToExist` option to `dao.patch`

### DIFF
--- a/src/commondao/common.dao.model.ts
+++ b/src/commondao/common.dao.model.ts
@@ -297,8 +297,20 @@ export interface CommonDaoPatchOptions<DBM extends BaseDBEntity>
   extends CommonDaoSaveBatchOptions<DBM> {
   /**
    * If true - patch will skip loading from DB, and will just optimistically patch passed object.
+   *
+   * The flag is not applied when requireToExist is true, as it doesn't make sense.
    */
   skipDBRead?: boolean
+  /**
+   * Defaults to false.
+   * With false, if the row doesn't exist - it will be auto-created with `dao.create`.
+   * With true, if the row doesn't exist - it will throw an error.
+   *
+   * Use true when you expect the row to exist and it would be an error if it doesn't.
+   *
+   * When true, skipDBRead will not be applied, as it doesn't make sense.
+   */
+  requireToExist?: boolean
 }
 
 /**

--- a/src/commondao/common.dao.ts
+++ b/src/commondao/common.dao.ts
@@ -716,7 +716,7 @@ export class CommonDao<BM extends BaseDBEntity, DBM extends BaseDBEntity = BM, I
       return await this.patchInTransaction(bm, patch, opt)
     }
 
-    if (opt.skipDBRead) {
+    if (opt.skipDBRead && !opt.requireToExist) {
       const patched: BM = {
         ...bm,
         ...patch,
@@ -749,6 +749,11 @@ export class CommonDao<BM extends BaseDBEntity, DBM extends BaseDBEntity = BM, I
           return bm
         }
       } else {
+        const table = opt.table || this.cfg.table
+        _assert(!opt.requireToExist, `${table}.patch row is required, but missing`, {
+          id: bm.id,
+          table,
+        })
         Object.assign(bm, patch)
       }
     }


### PR DESCRIPTION
In this PR, I implement the `requireToExist` option in `dao.patch`.

Currently it exists only in `patchById`.

---

Ceterum censeo: not just the common logic, but even the typing suggests that `.patch` works on already saved data.
Hence, I think it would be idiomatic even in NoSQL world that a `.patch` by default expects the object to exist.

I'd suggest that we do not merge this PR,
instead make the dao throw when `.patch` is called on a non existing entity,
except when `skipDBRead` is passed.