### PR TITLE
feat: make patch throw when item is missing from DB

### DIFF
--- a/src/commondao/common.dao.model.ts
+++ b/src/commondao/common.dao.model.ts
@@ -301,14 +301,6 @@ export interface CommonDaoPatchOptions<DBM extends BaseDBEntity>
    * Consequently, when the row doesn't exist - it will be auto-created with `dao.create`.
    */
   skipDBRead?: boolean
-  /**
-   * Defaults to false.
-   * With false, if the row doesn't exist - it will throw an error.
-   * With true, if the row doesn't exist - it will be auto-created with `dao.create`.
-   *
-   * Use true when you expect the row to exist and it would be an error if it doesn't.
-   */
-  createIfMissing?: boolean
 }
 
 /**

--- a/src/commondao/common.dao.model.ts
+++ b/src/commondao/common.dao.model.ts
@@ -285,20 +285,30 @@ export interface CommonDaoPatchByIdOptions<DBM extends BaseDBEntity>
   extends CommonDaoSaveBatchOptions<DBM> {
   /**
    * Defaults to false.
-   * With false, if the row doesn't exist - it will be auto-created with `dao.create`.
-   * With true, if the row doesn't exist - it will throw an error.
+   * With false, if the row doesn't exist - it will throw an error.
+   * With true, if the row doesn't exist - it will be auto-created with `dao.create`.
    *
    * Use true when you expect the row to exist and it would be an error if it doesn't.
    */
-  requireToExist?: boolean
+  createIfMissing?: boolean
 }
 
 export interface CommonDaoPatchOptions<DBM extends BaseDBEntity>
   extends CommonDaoSaveBatchOptions<DBM> {
   /**
    * If true - patch will skip loading from DB, and will just optimistically patch passed object.
+   *
+   * Consequently, when the row doesn't exist - it will be auto-created with `dao.create`.
    */
   skipDBRead?: boolean
+  /**
+   * Defaults to false.
+   * With false, if the row doesn't exist - it will throw an error.
+   * With true, if the row doesn't exist - it will be auto-created with `dao.create`.
+   *
+   * Use true when you expect the row to exist and it would be an error if it doesn't.
+   */
+  createIfMissing?: boolean
 }
 
 /**

--- a/src/commondao/common.dao.test.ts
+++ b/src/commondao/common.dao.test.ts
@@ -156,6 +156,14 @@ test('should propagate pipe errors', async () => {
 
 test('patchById', async () => {
   const id = '123456'
+  const testItem: TestItemBM = {
+    id,
+    k1: 'k1',
+    created: 1529539200 as UnixTimestamp,
+    updated: 1529539200 as UnixTimestamp,
+  }
+  await dao.save(testItem)
+
   const r = await dao.patchById(id, {
     k1: 'k111',
   })
@@ -173,7 +181,7 @@ test('patchById', async () => {
   `)
 })
 
-test('patchById requireToExist', async () => {
+test('patchById createIfMissing false', async () => {
   const id = '123456'
   expect(
     await pExpectedErrorString(
@@ -183,11 +191,11 @@ test('patchById requireToExist', async () => {
           k1: 'k111',
         },
         {
-          requireToExist: true,
+          createIfMissing: false,
         },
       ),
     ),
-  ).toMatchInlineSnapshot(`"AssertionError: TEST_TABLE.patchById row is required, but missing"`)
+  ).toMatchInlineSnapshot(`"AssertionError: DB row required, but not found in TEST_TABLE"`)
 })
 
 describe('patch', () => {
@@ -222,10 +230,10 @@ describe('patch', () => {
       }),
     )
 
-    expect(error).toBe('AppError: DB row required, but not found in TEST_TABLE')
+    expect(error).toBe(`AssertionError: DB row required, but not found in TEST_TABLE`)
   })
 
-  test('should not throw when data does not exist but `skipDBRead` is specified', async () => {
+  test('should create the data when it does not exist and `skipDBRead` is specified', async () => {
     const testItem: TestItemBM = {
       id: 'id1',
       k1: 'k1',
@@ -245,6 +253,55 @@ describe('patch', () => {
 
     const updatedTestItem = await dao.requireById('id1')
     expect(updatedTestItem).toMatchObject({ k1: 'k111' })
+  })
+
+  test('should create the data when it does not exist and `createIfMissing` is specified', async () => {
+    const testItem: TestItemBM = {
+      id: 'id1',
+      k1: 'k1',
+      created: 1529539200 as UnixTimestamp,
+      updated: 1529539200 as UnixTimestamp,
+    }
+
+    await dao.patch(
+      testItem,
+      {
+        k1: 'k111',
+      },
+      {
+        createIfMissing: true,
+      },
+    )
+
+    const updatedTestItem = await dao.requireById('id1')
+    expect(updatedTestItem).toMatchObject({ k1: 'k111' })
+  })
+
+  test('should throw when `skipDBRead` is true and `createIfMissing` is `false`', async () => {
+    const testItem: TestItemBM = {
+      id: 'id1',
+      k1: 'k1',
+      created: 1529539200 as UnixTimestamp,
+      updated: 1529539200 as UnixTimestamp,
+    }
+    await dao.save(testItem)
+
+    const error = await pExpectedErrorString(
+      dao.patch(
+        testItem,
+        {
+          k1: 'k111',
+        },
+        {
+          skipDBRead: true,
+          createIfMissing: false,
+        },
+      ),
+    )
+
+    expect(error).toBe(
+      'AssertionError: When `skipDBRead` is set to `true`, `createIfMissing` must not be `false`',
+    )
   })
 })
 

--- a/src/commondao/common.dao.test.ts
+++ b/src/commondao/common.dao.test.ts
@@ -230,7 +230,7 @@ describe('patch', () => {
       }),
     )
 
-    expect(error).toBe(`AssertionError: DB row required, but not found in TEST_TABLE`)
+    expect(error).toBe(`AppError: DB row required, but not found in TEST_TABLE`)
   })
 
   test('should create the data when it does not exist and `skipDBRead` is specified', async () => {
@@ -253,55 +253,6 @@ describe('patch', () => {
 
     const updatedTestItem = await dao.requireById('id1')
     expect(updatedTestItem).toMatchObject({ k1: 'k111' })
-  })
-
-  test('should create the data when it does not exist and `createIfMissing` is specified', async () => {
-    const testItem: TestItemBM = {
-      id: 'id1',
-      k1: 'k1',
-      created: 1529539200 as UnixTimestamp,
-      updated: 1529539200 as UnixTimestamp,
-    }
-
-    await dao.patch(
-      testItem,
-      {
-        k1: 'k111',
-      },
-      {
-        createIfMissing: true,
-      },
-    )
-
-    const updatedTestItem = await dao.requireById('id1')
-    expect(updatedTestItem).toMatchObject({ k1: 'k111' })
-  })
-
-  test('should throw when `skipDBRead` is true and `createIfMissing` is `false`', async () => {
-    const testItem: TestItemBM = {
-      id: 'id1',
-      k1: 'k1',
-      created: 1529539200 as UnixTimestamp,
-      updated: 1529539200 as UnixTimestamp,
-    }
-    await dao.save(testItem)
-
-    const error = await pExpectedErrorString(
-      dao.patch(
-        testItem,
-        {
-          k1: 'k111',
-        },
-        {
-          skipDBRead: true,
-          createIfMissing: false,
-        },
-      ),
-    )
-
-    expect(error).toBe(
-      'AssertionError: When `skipDBRead` is set to `true`, `createIfMissing` must not be `false`',
-    )
   })
 })
 

--- a/src/commondao/common.dao.test.ts
+++ b/src/commondao/common.dao.test.ts
@@ -190,6 +190,64 @@ test('patchById requireToExist', async () => {
   ).toMatchInlineSnapshot(`"AssertionError: TEST_TABLE.patchById row is required, but missing"`)
 })
 
+describe('patch', () => {
+  test('should patch when the data exists', async () => {
+    const testItem: TestItemBM = {
+      id: 'id1',
+      k1: 'k1',
+      created: 1529539200 as UnixTimestamp,
+      updated: 1529539200 as UnixTimestamp,
+    }
+    await dao.save(testItem)
+
+    await dao.patch(testItem, {
+      k1: 'k111',
+    })
+
+    const updatedTestItem = await dao.requireById('id1')
+    expect(updatedTestItem).toMatchObject({ k1: 'k111' })
+  })
+
+  test('should throw when the data does not exist', async () => {
+    const testItem: TestItemBM = {
+      id: 'id1',
+      k1: 'k1',
+      created: 1529539200 as UnixTimestamp,
+      updated: 1529539200 as UnixTimestamp,
+    }
+
+    const error = await pExpectedErrorString(
+      dao.patch(testItem, {
+        k1: 'k111',
+      }),
+    )
+
+    expect(error).toBe('AppError: DB row required, but not found in TEST_TABLE')
+  })
+
+  test('should not throw when data does not exist but `skipDBRead` is specified', async () => {
+    const testItem: TestItemBM = {
+      id: 'id1',
+      k1: 'k1',
+      created: 1529539200 as UnixTimestamp,
+      updated: 1529539200 as UnixTimestamp,
+    }
+
+    await dao.patch(
+      testItem,
+      {
+        k1: 'k111',
+      },
+      {
+        skipDBRead: true,
+      },
+    )
+
+    const updatedTestItem = await dao.requireById('id1')
+    expect(updatedTestItem).toMatchObject({ k1: 'k111' })
+  })
+})
+
 test('patch', async () => {
   const item: TestItemBM = await dao.save({
     id: 'id1',

--- a/src/commondao/common.dao.ts
+++ b/src/commondao/common.dao.ts
@@ -728,28 +728,24 @@ export class CommonDao<BM extends BaseDBEntity, DBM extends BaseDBEntity = BM, I
       }
       Object.assign(bm, patch)
     } else {
-      const loaded = await this.getById(bm.id as ID, {
+      const loaded = await this.requireById(bm.id as ID, {
         // Skipping validation here for performance reasons.
         // Validation is going to happen on save anyway, just down below.
         skipValidation: true,
         ...opt,
       })
 
-      if (loaded) {
-        const loadedWithPatch: BM = {
-          ...loaded,
-          ...patch,
-        }
+      const loadedWithPatch: BM = {
+        ...loaded,
+        ...patch,
+      }
 
-        // Make `bm` exactly the same as `loadedWithPatch`
-        _objectAssignExact(bm, loadedWithPatch)
+      // Make `bm` exactly the same as `loadedWithPatch`
+      _objectAssignExact(bm, loadedWithPatch)
 
-        if (_deepJsonEquals(loaded, loadedWithPatch)) {
-          // Skipping the save operation, as data is the same
-          return bm
-        }
-      } else {
-        Object.assign(bm, patch)
+      if (_deepJsonEquals(loaded, loadedWithPatch)) {
+        // Skipping the save operation, as data is the same
+        return bm
       }
     }
 

--- a/src/commondao/common.dao.ts
+++ b/src/commondao/common.dao.ts
@@ -717,10 +717,6 @@ export class CommonDao<BM extends BaseDBEntity, DBM extends BaseDBEntity = BM, I
     }
 
     if (opt.skipDBRead) {
-      _assert(
-        opt.createIfMissing === undefined || opt.createIfMissing,
-        'When `skipDBRead` is set to `true`, `createIfMissing` must not be `false`',
-      )
       const patched: BM = {
         ...bm,
         ...patch,
@@ -732,33 +728,24 @@ export class CommonDao<BM extends BaseDBEntity, DBM extends BaseDBEntity = BM, I
       }
       Object.assign(bm, patch)
     } else {
-      const loaded = await this.getById(bm.id as ID, {
+      const loaded = await this.requireById(bm.id as ID, {
         // Skipping validation here for performance reasons.
         // Validation is going to happen on save anyway, just down below.
         skipValidation: true,
         ...opt,
       })
 
-      if (loaded) {
-        const loadedWithPatch: BM = {
-          ...loaded,
-          ...patch,
-        }
+      const loadedWithPatch: BM = {
+        ...loaded,
+        ...patch,
+      }
 
-        // Make `bm` exactly the same as `loadedWithPatch`
-        _objectAssignExact(bm, loadedWithPatch)
+      // Make `bm` exactly the same as `loadedWithPatch`
+      _objectAssignExact(bm, loadedWithPatch)
 
-        if (_deepJsonEquals(loaded, loadedWithPatch)) {
-          // Skipping the save operation, as data is the same
-          return bm
-        }
-      } else {
-        const table = opt.table || this.cfg.table
-        _assert(opt.createIfMissing, `DB row required, but not found in ${table}`, {
-          id: bm.id,
-          table,
-        })
-        Object.assign(bm, patch)
+      if (_deepJsonEquals(loaded, loadedWithPatch)) {
+        // Skipping the save operation, as data is the same
+        return bm
       }
     }
 


### PR DESCRIPTION
In this PR, I refactor `dao.patch` to throw when the item-to-be-patched does not exist in the DB rather than creating the item.

---

Author's note:
I still think that `.patchById` should work the same way. 

Reason 1:
It will be a weird and confusing discrepancy between patching and patching-by-id.

Reason 2:
We may start creating invalid data.
```ts
userDao.patchById('non-existing-id', { name: "A" })
// this will create User{ id: 'non-existing-id', name: 'A'} - which is missing a lot of mandatory fields
```
